### PR TITLE
[Section/#3] 폼 다루기 & 인증 기능 구현하기

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -1,9 +1,15 @@
 import React from 'react';
 import './global.css';
-import RootNavigation from './src/navigations/RootNavigation';
+import RootNavigation from '@/navigations/RootNavigation';
+import {QueryClientProvider} from '@tanstack/react-query';
+import {queryClient} from '@/api/queryClient';
 
 function App() {
-  return <RootNavigation />;
+  return (
+    <QueryClientProvider client={queryClient}>
+      <RootNavigation />
+    </QueryClientProvider>
+  );
 }
 
 export default App;

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1332,6 +1332,8 @@ PODS:
     - React-jsiexecutor
     - React-RCTFBReactNativeSpec
     - ReactCommon/turbomodule/core
+  - react-native-encrypted-storage (4.0.3):
+    - React-Core
   - react-native-safe-area-context (5.6.2):
     - DoubleConversion
     - glog
@@ -2074,6 +2076,7 @@ DEPENDENCIES:
   - React-logger (from `../node_modules/react-native/ReactCommon/logger`)
   - React-Mapbuffer (from `../node_modules/react-native/ReactCommon`)
   - React-microtasksnativemodule (from `../node_modules/react-native/ReactCommon/react/nativemodule/microtasks`)
+  - react-native-encrypted-storage (from `../node_modules/react-native-encrypted-storage`)
   - react-native-safe-area-context (from `../node_modules/react-native-safe-area-context`)
   - "react-native-vector-icons-fontawesome6 (from `../node_modules/@react-native-vector-icons/fontawesome6`)"
   - "react-native-vector-icons-ionicons (from `../node_modules/@react-native-vector-icons/ionicons`)"
@@ -2198,6 +2201,8 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native/ReactCommon"
   React-microtasksnativemodule:
     :path: "../node_modules/react-native/ReactCommon/react/nativemodule/microtasks"
+  react-native-encrypted-storage:
+    :path: "../node_modules/react-native-encrypted-storage"
   react-native-safe-area-context:
     :path: "../node_modules/react-native-safe-area-context"
   react-native-vector-icons-fontawesome6:
@@ -2320,6 +2325,7 @@ SPEC CHECKSUMS:
   React-logger: 694787b12186eeeadccdfdc6769890e9080c1f11
   React-Mapbuffer: a0ee08ac29b8a2c08692aa0d51cefa1c88860e17
   React-microtasksnativemodule: ef2292ca147fa8793305e4693586ad0caf3afad3
+  react-native-encrypted-storage: 569d114e329b1c2c2d9f8c84bcdbe4478dda2258
   react-native-safe-area-context: 0b8555c40461feb7198e999912a3446602e7c601
   react-native-vector-icons-fontawesome6: 1a73ea16a698f70851ad47e94521a99499e8e974
   react-native-vector-icons-ionicons: ad07e944a092a5cf71b8b569d8f5ce2bf674c415

--- a/package.json
+++ b/package.json
@@ -10,23 +10,29 @@
     "test": "jest"
   },
   "dependencies": {
+    "@hookform/resolvers": "^5.2.2",
     "@react-native-masked-view/masked-view": "^0.3.2",
     "@react-native-vector-icons/fontawesome6": "^12.3.0",
     "@react-native-vector-icons/ionicons": "^12.3.0",
     "@react-navigation/drawer": "^7.7.2",
     "@react-navigation/native": "^7.1.19",
     "@react-navigation/stack": "^7.6.3",
+    "@tanstack/react-query": "^5.90.12",
+    "axios": "^1.13.2",
     "babel-plugin-module-resolver": "^5.0.2",
     "nativewind": "^4.2.1",
     "react": "19.0.0",
+    "react-hook-form": "^7.69.0",
     "react-native": "0.79.4",
     "react-native-css-interop": "^0.2.1",
+    "react-native-encrypted-storage": "^4.0.3",
     "react-native-gesture-handler": "^2.29.1",
     "react-native-reanimated": "^4.1.3",
     "react-native-safe-area-context": "^5.6.2",
     "react-native-screens": "^4.18.0",
     "react-native-svg": "^15.15.0",
-    "react-native-worklets": "^0.6.1"
+    "react-native-worklets": "^0.6.1",
+    "yup": "^1.7.1"
   },
   "devDependencies": {
     "@babel/core": "^7.25.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@hookform/resolvers':
+        specifier: ^5.2.2
+        version: 5.2.2(react-hook-form@7.69.0(react@19.0.0))
       '@react-native-masked-view/masked-view':
         specifier: ^0.3.2
         version: 0.3.2(react-native@0.79.4(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@5.0.4))(@types/react@19.2.5)(react@19.0.0))(react@19.0.0)
@@ -26,6 +29,12 @@ importers:
       '@react-navigation/stack':
         specifier: ^7.6.3
         version: 7.6.4(be530265cbc146c53d7f10d41453c3eb)
+      '@tanstack/react-query':
+        specifier: ^5.90.12
+        version: 5.90.12(react@19.0.0)
+      axios:
+        specifier: ^1.13.2
+        version: 1.13.2
       babel-plugin-module-resolver:
         specifier: ^5.0.2
         version: 5.0.2
@@ -35,12 +44,18 @@ importers:
       react:
         specifier: 19.0.0
         version: 19.0.0
+      react-hook-form:
+        specifier: ^7.69.0
+        version: 7.69.0(react@19.0.0)
       react-native:
         specifier: 0.79.4
         version: 0.79.4(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@5.0.4))(@types/react@19.2.5)(react@19.0.0)
       react-native-css-interop:
         specifier: ^0.2.1
         version: 0.2.1(react-native-reanimated@4.1.5(@babel/core@7.28.5)(react-native-worklets@0.6.1(@babel/core@7.28.5)(react-native@0.79.4(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@5.0.4))(@types/react@19.2.5)(react@19.0.0))(react@19.0.0))(react-native@0.79.4(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@5.0.4))(@types/react@19.2.5)(react@19.0.0))(react@19.0.0))(react-native-safe-area-context@5.6.2(react-native@0.79.4(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@5.0.4))(@types/react@19.2.5)(react@19.0.0))(react@19.0.0))(react-native-svg@15.15.0(react-native@0.79.4(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@5.0.4))(@types/react@19.2.5)(react@19.0.0))(react@19.0.0))(react-native@0.79.4(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@5.0.4))(@types/react@19.2.5)(react@19.0.0))(react@19.0.0)(tailwindcss@3.4.18(yaml@2.8.1))
+      react-native-encrypted-storage:
+        specifier: ^4.0.3
+        version: 4.0.3(react-native@0.79.4(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@5.0.4))(@types/react@19.2.5)(react@19.0.0))(react@19.0.0)
       react-native-gesture-handler:
         specifier: ^2.29.1
         version: 2.29.1(react-native@0.79.4(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@5.0.4))(@types/react@19.2.5)(react@19.0.0))(react@19.0.0)
@@ -59,6 +74,9 @@ importers:
       react-native-worklets:
         specifier: ^0.6.1
         version: 0.6.1(@babel/core@7.28.5)(react-native@0.79.4(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@5.0.4))(@types/react@19.2.5)(react@19.0.0))(react@19.0.0)
+      yup:
+        specifier: ^1.7.1
+        version: 1.7.1
     devDependencies:
       '@babel/core':
         specifier: ^7.25.2
@@ -831,6 +849,11 @@ packages:
   '@hapi/topo@5.1.0':
     resolution: {integrity: sha512-foQZKJig7Ob0BMAYBfcJk8d77QtOe7Wo4ox7ff1lQYoNNAb6jwcY1ncdoy2e9wQZzvNy7ODZCYJkK8kzmcAnAg==}
 
+  '@hookform/resolvers@5.2.2':
+    resolution: {integrity: sha512-A/IxlMLShx3KjV/HeTcTfaMxdwy690+L/ZADoeaTltLx+CVuzkeVIPuybK3jrRfw7YZnmdKsVVHAlEPIAEUNlA==}
+    peerDependencies:
+      react-hook-form: ^7.55.0
+
   '@humanwhocodes/config-array@0.13.0':
     resolution: {integrity: sha512-DZLEEqFWQFiyK6h5YIeynKx7JlvCYWL0cImfSRXZ9l4Sg2efkFGTuFf6vzXjK1cq6IYkU+Eg/JizXw+TD2vRNw==}
     engines: {node: '>=10.10.0'}
@@ -1226,6 +1249,9 @@ packages:
   '@sinonjs/fake-timers@10.3.0':
     resolution: {integrity: sha512-V4BG07kuYSUkTCSBHG8G8TNhM+F19jXFWnQtzj+we8DrkpSBCee9Z3Ms8yiGer/dlmhe35/Xdgyo3/0rQKg7YA==}
 
+  '@standard-schema/utils@0.3.0':
+    resolution: {integrity: sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==}
+
   '@svgr/babel-plugin-add-jsx-attribute@8.0.0':
     resolution: {integrity: sha512-b9MIk7yhdS1pMCZM8VeNfUlSKVRhsHZNMl5O9SfaX0l0t5wjdgu4IDzGB8bpnGBBOjGST3rRFVsaaEtI4W6f7g==}
     engines: {node: '>=14'}
@@ -1299,6 +1325,14 @@ packages:
     engines: {node: '>=14'}
     peerDependencies:
       '@svgr/core': '*'
+
+  '@tanstack/query-core@5.90.12':
+    resolution: {integrity: sha512-T1/8t5DhV/SisWjDnaiU2drl6ySvsHj1bHBCWNXd+/T+Hh1cf6JodyEYMd5sgwm+b/mETT4EV3H+zCVczCU5hg==}
+
+  '@tanstack/react-query@5.90.12':
+    resolution: {integrity: sha512-graRZspg7EoEaw0a8faiUASCyJrqjKPdqJ9EwuDRUF9mEYJ1YPczI9H+/agJ0mOJkPCJDk0lsz5QTrLZ/jQ2rg==}
+    peerDependencies:
+      react: ^18 || ^19
 
   '@trysound/sax@0.2.0':
     resolution: {integrity: sha512-L7z9BgrNEcYyUYtF+HaEfiS5ebkh9jXqbszz7pC0hRBPaatV0XjSD3+eHrpqFemQfgwiFF0QPIarnIihIDn7OA==}
@@ -1587,9 +1621,15 @@ packages:
   async-limiter@1.0.1:
     resolution: {integrity: sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ==}
 
+  asynckit@0.4.0:
+    resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
+
   available-typed-arrays@1.0.7:
     resolution: {integrity: sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==}
     engines: {node: '>= 0.4'}
+
+  axios@1.13.2:
+    resolution: {integrity: sha512-VPk9ebNqPcy5lRGuSlKx752IlDatOjT9paPlm8A7yOuW2Fbvp4X3JznJtT4f0GzGLLiWE9W8onz51SqLYwzGaA==}
 
   babel-jest@29.7.0:
     resolution: {integrity: sha512-BrvGY3xZSwEcCzKvKsCi2GgHqDqsYkOP4/by5xCgIwGXQxIEh+8ew3gmrE1y7XRR6LHZIj6yLYnUi/mm2KXKBg==}
@@ -1814,6 +1854,10 @@ packages:
   colorette@1.4.0:
     resolution: {integrity: sha512-Y2oEozpomLn7Q3HFP7dpww7AtMJplbM9lGZP6RDfHqmbeRjiwRg4n6VM6j4KLmRke85uWEI7JqF17f3pqdRA0g==}
 
+  combined-stream@1.0.8:
+    resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
+    engines: {node: '>= 0.8'}
+
   command-exists@1.2.9:
     resolution: {integrity: sha512-LTQ/SGc+s0Xc0Fu5WaKnR0YiygZkm9eKFvyS+fRsU7/ZWFF8ykFM6Pc9aCVf1+xasOOZpO3BAVgVrKvsqKHV7w==}
 
@@ -1995,6 +2039,10 @@ packages:
   define-properties@1.2.1:
     resolution: {integrity: sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==}
     engines: {node: '>= 0.4'}
+
+  delayed-stream@1.0.0:
+    resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
+    engines: {node: '>=0.4.0'}
 
   depd@2.0.0:
     resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
@@ -2350,6 +2398,15 @@ packages:
   flow-enums-runtime@0.0.6:
     resolution: {integrity: sha512-3PYnM29RFXwvAN6Pc/scUfkI7RwhQ/xqyLUyPNlXUp9S40zI8nup9tUSrTLSVnWGBN38FNiGWbwZOB6uR4OGdw==}
 
+  follow-redirects@1.15.11:
+    resolution: {integrity: sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==}
+    engines: {node: '>=4.0'}
+    peerDependencies:
+      debug: '*'
+    peerDependenciesMeta:
+      debug:
+        optional: true
+
   for-each@0.3.5:
     resolution: {integrity: sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==}
     engines: {node: '>= 0.4'}
@@ -2357,6 +2414,10 @@ packages:
   foreground-child@3.3.1:
     resolution: {integrity: sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==}
     engines: {node: '>=14'}
+
+  form-data@4.0.5:
+    resolution: {integrity: sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==}
+    engines: {node: '>= 6'}
 
   fresh@0.5.2:
     resolution: {integrity: sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==}
@@ -3605,6 +3666,12 @@ packages:
   prop-types@15.8.1:
     resolution: {integrity: sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==}
 
+  property-expr@2.0.6:
+    resolution: {integrity: sha512-SVtmxhRE/CGkn3eZY1T6pC8Nln6Fr/lu1mKSgRud0eC73whjGfoAogbn78LkD8aFL0zz3bAFerKSnOl7NlErBA==}
+
+  proxy-from-env@1.1.0:
+    resolution: {integrity: sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==}
+
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
@@ -3643,6 +3710,12 @@ packages:
     peerDependencies:
       react: '>=17.0.0'
 
+  react-hook-form@7.69.0:
+    resolution: {integrity: sha512-yt6ZGME9f4F6WHwevrvpAjh42HMvocuSnSIHUGycBqXIJdhqGSPQzTpGF+1NLREk/58IdPxEMfPcFCjlMhclGw==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      react: ^16.8.0 || ^17 || ^18 || ^19
+
   react-is@16.13.1:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
 
@@ -3678,6 +3751,12 @@ packages:
       react-native: '*'
       react-native-gesture-handler: '>= 2.0.0'
       react-native-reanimated: '>= 2.0.0'
+
+  react-native-encrypted-storage@4.0.3:
+    resolution: {integrity: sha512-0pJA4Aj2S1PIJEbU7pN/Qvf7JIJx3hFywx+i+bLHtgK0/6Zryf1V2xVsWcrD50dfiu3jY1eN2gesQ5osGxE7jA==}
+    peerDependencies:
+      react: '*'
+      react-native: '*'
 
   react-native-gesture-handler@2.29.1:
     resolution: {integrity: sha512-du3qmv0e3Sm7qsd9SfmHps+AggLiylcBBQ8ztz7WUtd8ZjKs5V3kekAbi9R2W9bRLSg47Ntp4GGMYZOhikQdZA==}
@@ -4134,6 +4213,9 @@ packages:
   throat@5.0.0:
     resolution: {integrity: sha512-fcwX4mndzpLQKBS1DVYhGAcYaYt7vsHNIvQV+WXMvnow5cgjPphq5CaayLaGsjRdSCKZFNGt7/GYAuXaNOiYCA==}
 
+  tiny-case@1.0.3:
+    resolution: {integrity: sha512-Eet/eeMhkO6TX8mnUteS9zgPbUMQa4I6Kkp5ORiBD5476/m+PIRiumP5tmh5ioJpH7k51Kehawy2UDfsnxxY8Q==}
+
   tmpl@1.0.5:
     resolution: {integrity: sha512-3f0uOEAQwIqGuWW2MVzYg8fV/QNnc/IpuJNG837rLuczAaLVHslWHZQj4IGiEl5Hs3kkbhwL9Ab7Hrsmuj+Smw==}
 
@@ -4144,6 +4226,9 @@ packages:
   toidentifier@1.0.1:
     resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
     engines: {node: '>=0.6'}
+
+  toposort@2.0.2:
+    resolution: {integrity: sha512-0a5EOkAUp8D4moMi2W8ZF8jcga7BgZd91O/yabJCFY8az+XSzeGyTKs0Aoo897iV1Nj6guFq8orWDS96z91oGg==}
 
   ts-api-utils@1.4.3:
     resolution: {integrity: sha512-i3eMG77UTMD0hZhgRS562pv83RC6ukSAC2GMNWc+9dieh/+jDM5u5YG+NHX6VNDRHQcHwmsTHctP9LhbC3WxVw==}
@@ -4185,6 +4270,10 @@ packages:
   type-fest@0.7.1:
     resolution: {integrity: sha512-Ne2YiiGN8bmrmJJEuTWTLJR32nh/JdL1+PSicowtNb0WFpn59GK8/lfD61bVtzguz7b3PBt74nxpv/Pw5po5Rg==}
     engines: {node: '>=8'}
+
+  type-fest@2.19.0:
+    resolution: {integrity: sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==}
+    engines: {node: '>=12.20'}
 
   type-is@1.6.18:
     resolution: {integrity: sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==}
@@ -4407,6 +4496,9 @@ packages:
   yocto-queue@1.2.2:
     resolution: {integrity: sha512-4LCcse/U2MHZ63HAJVE+v71o7yOdIe4cZ70Wpf8D/IyjDKYQLV5GD46B+hSTjJsvV5PztjvHoU580EftxjDZFQ==}
     engines: {node: '>=12.20'}
+
+  yup@1.7.1:
+    resolution: {integrity: sha512-GKHFX2nXul2/4Dtfxhozv701jLQHdf6J34YDh2cEkpqoo8le5Mg6/LrdseVLrFarmFygZTlfIhHx/QKfb/QWXw==}
 
 snapshots:
 
@@ -5275,6 +5367,11 @@ snapshots:
     dependencies:
       '@hapi/hoek': 9.3.0
 
+  '@hookform/resolvers@5.2.2(react-hook-form@7.69.0(react@19.0.0))':
+    dependencies:
+      '@standard-schema/utils': 0.3.0
+      react-hook-form: 7.69.0(react@19.0.0)
+
   '@humanwhocodes/config-array@0.13.0':
     dependencies:
       '@humanwhocodes/object-schema': 2.0.3
@@ -5994,6 +6091,8 @@ snapshots:
     dependencies:
       '@sinonjs/commons': 3.0.1
 
+  '@standard-schema/utils@0.3.0': {}
+
   '@svgr/babel-plugin-add-jsx-attribute@8.0.0(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
@@ -6072,6 +6171,13 @@ snapshots:
       svgo: 3.3.2
     transitivePeerDependencies:
       - typescript
+
+  '@tanstack/query-core@5.90.12': {}
+
+  '@tanstack/react-query@5.90.12(react@19.0.0)':
+    dependencies:
+      '@tanstack/query-core': 5.90.12
+      react: 19.0.0
 
   '@trysound/sax@0.2.0': {}
 
@@ -6413,9 +6519,19 @@ snapshots:
 
   async-limiter@1.0.1: {}
 
+  asynckit@0.4.0: {}
+
   available-typed-arrays@1.0.7:
     dependencies:
       possible-typed-array-names: 1.1.0
+
+  axios@1.13.2:
+    dependencies:
+      follow-redirects: 1.15.11
+      form-data: 4.0.5
+      proxy-from-env: 1.1.0
+    transitivePeerDependencies:
+      - debug
 
   babel-jest@29.7.0(@babel/core@7.28.5):
     dependencies:
@@ -6711,6 +6827,10 @@ snapshots:
 
   colorette@1.4.0: {}
 
+  combined-stream@1.0.8:
+    dependencies:
+      delayed-stream: 1.0.0
+
   command-exists@1.2.9: {}
 
   commander@12.1.0: {}
@@ -6898,6 +7018,8 @@ snapshots:
       define-data-property: 1.1.4
       has-property-descriptors: 1.0.2
       object-keys: 1.1.1
+
+  delayed-stream@1.0.0: {}
 
   depd@2.0.0: {}
 
@@ -7350,6 +7472,8 @@ snapshots:
 
   flow-enums-runtime@0.0.6: {}
 
+  follow-redirects@1.15.11: {}
+
   for-each@0.3.5:
     dependencies:
       is-callable: 1.2.7
@@ -7358,6 +7482,14 @@ snapshots:
     dependencies:
       cross-spawn: 7.0.6
       signal-exit: 4.1.0
+
+  form-data@4.0.5:
+    dependencies:
+      asynckit: 0.4.0
+      combined-stream: 1.0.8
+      es-set-tostringtag: 2.1.0
+      hasown: 2.0.2
+      mime-types: 2.1.35
 
   fresh@0.5.2: {}
 
@@ -8821,6 +8953,10 @@ snapshots:
       object-assign: 4.1.1
       react-is: 16.13.1
 
+  property-expr@2.0.6: {}
+
+  proxy-from-env@1.1.0: {}
+
   punycode@2.3.1: {}
 
   pure-rand@6.1.0: {}
@@ -8863,6 +8999,10 @@ snapshots:
     dependencies:
       react: 19.0.0
 
+  react-hook-form@7.69.0(react@19.0.0):
+    dependencies:
+      react: 19.0.0
+
   react-is@16.13.1: {}
 
   react-is@17.0.2: {}
@@ -8897,6 +9037,11 @@ snapshots:
       react-native-gesture-handler: 2.29.1(react-native@0.79.4(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@5.0.4))(@types/react@19.2.5)(react@19.0.0))(react@19.0.0)
       react-native-reanimated: 4.1.5(@babel/core@7.28.5)(react-native-worklets@0.6.1(@babel/core@7.28.5)(react-native@0.79.4(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@5.0.4))(@types/react@19.2.5)(react@19.0.0))(react@19.0.0))(react-native@0.79.4(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@5.0.4))(@types/react@19.2.5)(react@19.0.0))(react@19.0.0)
       use-latest-callback: 0.2.6(react@19.0.0)
+
+  react-native-encrypted-storage@4.0.3(react-native@0.79.4(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@5.0.4))(@types/react@19.2.5)(react@19.0.0))(react@19.0.0):
+    dependencies:
+      react: 19.0.0
+      react-native: 0.79.4(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@5.0.4))(@types/react@19.2.5)(react@19.0.0)
 
   react-native-gesture-handler@2.29.1(react-native@0.79.4(@babel/core@7.28.5)(@react-native-community/cli@18.0.1(typescript@5.0.4))(@types/react@19.2.5)(react@19.0.0))(react@19.0.0):
     dependencies:
@@ -9489,6 +9634,8 @@ snapshots:
 
   throat@5.0.0: {}
 
+  tiny-case@1.0.3: {}
+
   tmpl@1.0.5: {}
 
   to-regex-range@5.0.1:
@@ -9496,6 +9643,8 @@ snapshots:
       is-number: 7.0.0
 
   toidentifier@1.0.1: {}
+
+  toposort@2.0.2: {}
 
   ts-api-utils@1.4.3(typescript@5.0.4):
     dependencies:
@@ -9523,6 +9672,8 @@ snapshots:
   type-fest@0.21.3: {}
 
   type-fest@0.7.1: {}
+
+  type-fest@2.19.0: {}
 
   type-is@1.6.18:
     dependencies:
@@ -9758,3 +9909,10 @@ snapshots:
   yocto-queue@0.1.0: {}
 
   yocto-queue@1.2.2: {}
+
+  yup@1.7.1:
+    dependencies:
+      property-expr: 2.0.6
+      tiny-case: 1.0.3
+      toposort: 2.0.2
+      type-fest: 2.19.0

--- a/src/api/auth.ts
+++ b/src/api/auth.ts
@@ -1,0 +1,40 @@
+import {RequestUserType, ResponseToken} from '@/types/auth';
+import axiosInstance from './axios';
+import {Profile} from '@/types/domain';
+import {getEncryptStorage} from '@/utils/encryptStorage';
+import {storageKeys} from '@/constants/keys';
+
+async function postSignup({email, password}: RequestUserType): Promise<void> {
+  await axiosInstance.post('/auth/signup', {email, password});
+}
+
+async function postLogin({
+  email,
+  password,
+}: RequestUserType): Promise<ResponseToken> {
+  const {data} = await axiosInstance.post('/auth/signin', {email, password});
+  return data;
+}
+
+async function getProfile(): Promise<Profile> {
+  const {data} = await axiosInstance.get('/auth/me');
+  return data;
+}
+
+async function getAccessToken(): Promise<ResponseToken> {
+  const refreshToken = await getEncryptStorage(storageKeys.REFRESH_TOKEN);
+
+  const {data} = await axiosInstance.get('/auth/token', {
+    headers: {
+      Authorization: `Bearer ${refreshToken}`,
+    },
+  });
+
+  return data;
+}
+
+async function logout(): Promise<void> {
+  await axiosInstance.post('/auth/logout');
+}
+
+export {postSignup, postLogin, getProfile, getAccessToken, logout};

--- a/src/api/axios.ts
+++ b/src/api/axios.ts
@@ -1,0 +1,15 @@
+import axios from 'axios';
+import {Platform} from 'react-native';
+
+// 실 기기에서 테스트 하고싶으면 자신의 로컬 IP로 변경할 것
+// ifconfig | grep inet 으로 알 수 있음
+export const baseURL = {
+  ios: 'http://localhost:3030',
+  android: 'http://10.0.2.2:3030',
+};
+
+const axiosInstance = axios.create({
+  baseURL: Platform.OS === 'android' ? baseURL.android : baseURL.ios,
+});
+
+export default axiosInstance;

--- a/src/api/queryClient.ts
+++ b/src/api/queryClient.ts
@@ -1,0 +1,13 @@
+import {QueryClient} from '@tanstack/react-query';
+
+export const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      retry: false,
+      staleTime: 1000 * 60,
+    },
+    mutations: {
+      retry: false,
+    },
+  },
+});

--- a/src/components/BigButton.tsx
+++ b/src/components/BigButton.tsx
@@ -1,6 +1,0 @@
-import {Button} from 'react-native';
-import colors from '@/styles/colors';
-
-export default function BigButton() {
-  return <Button title="로그인" color={colors.pink[700]} />;
-}

--- a/src/components/CustomButton.tsx
+++ b/src/components/CustomButton.tsx
@@ -1,0 +1,34 @@
+import {Pressable, View, type GestureResponderEvent} from 'react-native';
+import {Text} from 'react-native-gesture-handler';
+interface CustomButtonProps {
+  label: string;
+  variant?: 'filled' | 'outlined';
+  size?: 'large' | 'small';
+  onPress?: (event: GestureResponderEvent) => void;
+}
+
+function CustomButton({
+  label,
+  variant = 'filled',
+  size = 'large',
+  onPress,
+}: CustomButtonProps) {
+  return (
+    <Pressable onPress={onPress} className="w-full">
+      {({pressed}) => (
+        <View
+          className={`rounded-[3px] justify-center items-center
+          ${variant === 'filled' ? 'bg-color-pink-700' : 'border-[1px] border-color-pink-700 bg-white'}
+          ${size === 'large' ? 'w-full h-[45px]' : 'px-[12px] h-[35px]'}
+          ${pressed ? 'opacity-60' : 'opacity-100'}
+          `}>
+          <Text
+            className={`text-[14px] font-bold ${variant === 'filled' ? 'text-white' : 'text-color-pink-700'}`}>
+            {label}
+          </Text>
+        </View>
+      )}
+    </Pressable>
+  );
+}
+export default CustomButton;

--- a/src/components/CustomDrawerContent.tsx
+++ b/src/components/CustomDrawerContent.tsx
@@ -17,9 +17,7 @@ function CustomDrawerContent(props: DrawerContentComponentProps) {
       <DrawerContentScrollView {...props}>
         <View className="self-center pb-[30px] gap-[5px]">
           <Image source={require('@/assets/default-user.png')} />
-          <Text className="text-center font-[14px]">
-            {auth.nickname || 'User'}
-          </Text>
+          <Text className="text-center font-[14px]">{auth.nickname}</Text>
         </View>
         <DrawerItemList {...props} />
       </DrawerContentScrollView>

--- a/src/components/CustomDrawerContent.tsx
+++ b/src/components/CustomDrawerContent.tsx
@@ -7,14 +7,19 @@ import {Image, View} from 'react-native';
 import {SafeAreaView} from 'react-native-safe-area-context';
 import {Text} from 'react-native-gesture-handler';
 import Ionicons from '@react-native-vector-icons/ionicons';
+import useAuth from '@/hooks/useAuth';
 
 function CustomDrawerContent(props: DrawerContentComponentProps) {
+  const {auth} = useAuth();
+  console.log(auth);
   return (
     <SafeAreaView className="flex-1">
       <DrawerContentScrollView {...props}>
         <View className="self-center pb-[30px] gap-[5px]">
           <Image source={require('@/assets/default-user.png')} />
-          <Text className="text-center font-[14px]">User</Text>
+          <Text className="text-center font-[14px]">
+            {auth.nickname || 'User'}
+          </Text>
         </View>
         <DrawerItemList {...props} />
       </DrawerContentScrollView>

--- a/src/components/CustomDrawerContent.tsx
+++ b/src/components/CustomDrawerContent.tsx
@@ -11,7 +11,6 @@ import useAuth from '@/hooks/useAuth';
 
 function CustomDrawerContent(props: DrawerContentComponentProps) {
   const {auth} = useAuth();
-  console.log(auth);
   return (
     <SafeAreaView className="flex-1">
       <DrawerContentScrollView {...props}>

--- a/src/components/InputField.tsx
+++ b/src/components/InputField.tsx
@@ -1,0 +1,47 @@
+import {Ref} from 'react';
+import {Controller, useFormContext} from 'react-hook-form';
+import {Text, TextInput, TextInputProps, View} from 'react-native';
+
+interface InputFieldProps extends TextInputProps {
+  name: string;
+  ref?: Ref<TextInput>;
+}
+
+function InputField({name, ref, ...props}: InputFieldProps) {
+  const {
+    control,
+    formState: {errors},
+  } = useFormContext();
+
+  return (
+    <Controller
+      control={control}
+      name={name as any}
+      render={({field: {onChange, onBlur, value}}) => (
+        <View>
+          <TextInput
+            {...props}
+            autoCapitalize="none"
+            spellCheck={false}
+            submitBehavior="submit"
+            ref={ref}
+            autoCorrect={false}
+            className={`border-[1px] justify-center h-[50px] px-[10px] text-[16px] text-black
+                      ${errors[name] ? 'border-color-red-300' : 'border-color-gray-200'}
+            `}
+            onChangeText={onChange}
+            onBlur={onBlur}
+            value={value}
+          />
+          {errors[name] && (
+            <Text className="text-[12px] text-color-red-500 ">
+              {errors[name]?.message as string}
+            </Text>
+          )}
+        </View>
+      )}
+    />
+  );
+}
+
+export default InputField;

--- a/src/constants/keys.ts
+++ b/src/constants/keys.ts
@@ -1,0 +1,10 @@
+const queryKeys = {
+  AUTH: 'auth',
+  GET_ACCESS_TOKEN: 'getAccessToken',
+  GET_PROFILE: 'getProfile',
+};
+const storageKeys = {
+  REFRESH_TOKEN: 'refreshToken',
+};
+
+export {storageKeys, queryKeys};

--- a/src/constants/numbers.ts
+++ b/src/constants/numbers.ts
@@ -1,0 +1,5 @@
+const numbers = {
+  ACCESS_TOKEN_REFRESH_TIME: 1000 * 60 * 30 - 1000 * 60 * 3,
+};
+
+export default numbers;

--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -13,7 +13,6 @@ import {removeEncryptStorage, setEncryptStorage} from '@/utils/encryptStorage';
 import {removeHeader, setHeader} from '@/utils/header';
 import {useMutation, useQuery, useQueryClient} from '@tanstack/react-query';
 import {useEffect} from 'react';
-import {ref} from 'yup';
 
 function useSignup(mutationOptions?: UseMutationCustomOptions) {
   return useMutation({

--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -1,0 +1,116 @@
+import {
+  getAccessToken,
+  getProfile,
+  logout,
+  postLogin,
+  postSignup,
+} from '@/api/auth';
+import {queryKeys, storageKeys} from '@/constants/keys';
+import numbers from '@/constants/numbers';
+import {UseMutationCustomOptions, UseQueryCustomOptions} from '@/types/api';
+import {Profile} from '@/types/domain';
+import {removeEncryptStorage, setEncryptStorage} from '@/utils/encryptStorage';
+import {removeHeader, setHeader} from '@/utils/header';
+import {useMutation, useQuery, useQueryClient} from '@tanstack/react-query';
+import {useEffect} from 'react';
+import {ref} from 'yup';
+
+function useSignup(mutationOptions?: UseMutationCustomOptions) {
+  return useMutation({
+    mutationFn: postSignup,
+    ...mutationOptions,
+  });
+}
+
+function useLogin(mutationOptions?: UseMutationCustomOptions) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: postLogin,
+    onSuccess: async ({accessToken, refreshToken}) => {
+      setHeader('Authorization', `Bearer ${accessToken}`);
+      await setEncryptStorage(storageKeys.REFRESH_TOKEN, refreshToken);
+
+      queryClient.setQueryData([queryKeys.AUTH, queryKeys.GET_ACCESS_TOKEN], {
+        accessToken,
+        refreshToken,
+      });
+      queryClient.fetchQuery({
+        queryKey: [queryKeys.AUTH, queryKeys.GET_ACCESS_TOKEN],
+      });
+    },
+    ...mutationOptions,
+  });
+}
+
+function useGetRefreshToken() {
+  const queryClient = useQueryClient();
+
+  const {data, isSuccess, isError} = useQuery({
+    queryKey: [queryKeys.AUTH, queryKeys.GET_ACCESS_TOKEN],
+    queryFn: getAccessToken,
+    staleTime: numbers.ACCESS_TOKEN_REFRESH_TIME,
+    refetchInterval: numbers.ACCESS_TOKEN_REFRESH_TIME,
+  });
+  useEffect(() => {
+    if (!data) {
+      return;
+    }
+    setHeader('Authorization', `Bearer ${data.accessToken}`);
+    setEncryptStorage(storageKeys.REFRESH_TOKEN, data.refreshToken);
+
+    queryClient.refetchQueries({
+      queryKey: [queryKeys.AUTH, queryKeys.GET_PROFILE],
+    });
+  }, [data, queryClient]);
+
+  useEffect(() => {
+    if (!isError) {
+      return;
+    }
+
+    removeHeader('Authorization');
+    removeEncryptStorage(storageKeys.REFRESH_TOKEN);
+  }, [isError]);
+
+  return {isSuccess, isError};
+}
+
+function useGetProfile(queryOptions?: UseQueryCustomOptions<Profile>) {
+  return useQuery({
+    queryKey: [queryKeys.AUTH, queryKeys.GET_PROFILE],
+    queryFn: getProfile,
+    ...queryOptions,
+  });
+}
+
+function useLogout(mutationOptions?: UseMutationCustomOptions) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: logout,
+    onSuccess: async () => {
+      removeHeader('Authorization');
+      await removeEncryptStorage(storageKeys.REFRESH_TOKEN);
+      queryClient.resetQueries({queryKey: [queryKeys.AUTH]});
+    },
+    ...mutationOptions,
+  });
+}
+
+function useAuth() {
+  const signupMutation = useSignup();
+  const loginMutation = useLogin();
+
+  const refreshTokenQuery = useGetRefreshToken();
+  const logoutMutation = useLogout();
+  const {isSuccess: isLogin} = useGetProfile({
+    enabled: !!refreshTokenQuery.isSuccess,
+  });
+  return {
+    signupMutation,
+    loginMutation,
+    isLogin,
+    logoutMutation,
+  };
+}
+
+export default useAuth;

--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -54,8 +54,10 @@ function useGetRefreshToken() {
     if (!data) {
       return;
     }
-    setHeader('Authorization', `Bearer ${data.accessToken}`);
-    setEncryptStorage(storageKeys.REFRESH_TOKEN, data.refreshToken);
+    async () => {
+      setHeader('Authorization', `Bearer ${data.accessToken}`);
+      await setEncryptStorage(storageKeys.REFRESH_TOKEN, data.refreshToken);
+    };
 
     queryClient.refetchQueries({
       queryKey: [queryKeys.AUTH, queryKeys.GET_PROFILE],
@@ -68,7 +70,9 @@ function useGetRefreshToken() {
     }
 
     removeHeader('Authorization');
-    removeEncryptStorage(storageKeys.REFRESH_TOKEN);
+    (async () => {
+      await removeEncryptStorage(storageKeys.REFRESH_TOKEN);
+    })();
   }, [isError]);
 
   return {isSuccess, isError};
@@ -106,7 +110,7 @@ function useAuth() {
   });
   return {
     auth: {
-      id: data?.id || '',
+      id: data?.id || 0,
       email: data?.email || '',
       nickname: data?.nickname || '',
       imageUri: data?.imageUri || '',

--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -101,10 +101,16 @@ function useAuth() {
 
   const refreshTokenQuery = useGetRefreshToken();
   const logoutMutation = useLogout();
-  const {isSuccess: isLogin} = useGetProfile({
+  const {data, isSuccess: isLogin} = useGetProfile({
     enabled: !!refreshTokenQuery.isSuccess,
   });
   return {
+    auth: {
+      id: data?.id || '',
+      email: data?.email || '',
+      nickname: data?.nickname || '',
+      imageUri: data?.imageUri || '',
+    },
     signupMutation,
     loginMutation,
     isLogin,

--- a/src/navigations/AuthNavigation.tsx
+++ b/src/navigations/AuthNavigation.tsx
@@ -34,7 +34,7 @@ const AuthStack = createStackNavigator({
         title: '로그인',
       },
     },
-    SignUp: {
+    Signup: {
       screen: SignupScreen,
       options: {
         title: '회원가입',

--- a/src/navigations/RootNavigation.tsx
+++ b/src/navigations/RootNavigation.tsx
@@ -1,8 +1,9 @@
+import useAuth from '@/hooks/useAuth';
 import AuthNavigation from './AuthNavigation';
 import DrawerNavigation from './DrawerNavigation';
 
 function RootNavigation() {
-  const isLogin = true; // TODO: 로그인 상태에 따른 조건문 처리
+  const {isLogin} = useAuth();
   return <>{isLogin ? <DrawerNavigation /> : <AuthNavigation />}</>;
 }
 export default RootNavigation;

--- a/src/screens/auth/AuthHomeScreen.tsx
+++ b/src/screens/auth/AuthHomeScreen.tsx
@@ -1,17 +1,37 @@
 import {useNavigation} from '@react-navigation/native';
 import {StackNavigationProp} from '@react-navigation/stack';
-import {Text} from 'react-native';
-import {SafeAreaView} from 'react-native-safe-area-context';
+import {Pressable, Text, View, SafeAreaView} from 'react-native';
 import {AuthStackParamList} from '@/types/navigation';
-
+import CustomButton from '@/components/CustomButton';
+import Logo from '@/assets/MATZIP.svg';
 type Navigation = StackNavigationProp<AuthStackParamList>;
 const AuthHomeScreen = () => {
   const navigation = useNavigation<Navigation>();
   return (
-    <SafeAreaView>
-      <Text onPress={() => navigation.navigate('Login')}>
-        Welcome to the Auth Home Screen
-      </Text>
+    <SafeAreaView className="flex-1">
+      <View className="flex items-center flex-1 py-[150px]">
+        <Logo className="w-[200px] h-full"></Logo>
+      </View>
+      <View className="flex-1 px-[30px] flex flex-col w-full items-center gap-[5px]">
+        <CustomButton
+          label="이메일 로그인"
+          onPress={() => navigation.navigate('Login')}
+        />
+        <CustomButton
+          label="이메일 로그인"
+          variant="outlined"
+          onPress={() => navigation.navigate('Login')}
+        />
+        <CustomButton
+          label="이메일 로그인"
+          onPress={() => navigation.navigate('Login')}
+        />
+        <Pressable onPress={() => navigation.navigate('Signup')}>
+          <Text className="underline font-medium p-[10px] text-black">
+            이메일로 가입하기
+          </Text>
+        </Pressable>
+      </View>
     </SafeAreaView>
   );
 };

--- a/src/screens/auth/LoginScreen.tsx
+++ b/src/screens/auth/LoginScreen.tsx
@@ -1,11 +1,58 @@
-import {Text} from 'react-native';
-import {SafeAreaView} from 'react-native-safe-area-context';
-import BigButton from '@/components/BigButton';
+import {View, SafeAreaView, TextInput} from 'react-native';
+import InputField from '@/components/InputField';
+import CustomButton from '@/components/CustomButton';
+import {FormProvider, useForm} from 'react-hook-form';
+import {yupResolver} from '@hookform/resolvers/yup';
+import {loginSchema} from '@/validate/validate';
+import {LoginFormValues} from '@/types/auth';
+import {useRef} from 'react';
+import useAuth from '@/hooks/useAuth';
+
 const LoginScreen = () => {
+  const {loginMutation} = useAuth();
+  const passwordRef = useRef<TextInput | null>(null);
+  const methods = useForm<LoginFormValues>({
+    defaultValues: {
+      email: '',
+      password: '',
+    },
+    mode: 'onChange',
+    resolver: yupResolver(loginSchema),
+  });
+  const {handleSubmit} = methods;
+
+  const onSubmit = (data: any) => {
+    loginMutation.mutate(data);
+  };
+
   return (
-    <SafeAreaView>
-      <Text>Welcome to the Login Screen</Text>
-      <BigButton />
+    <SafeAreaView className="flex-1 m-[30px]">
+      <FormProvider {...methods}>
+        <View className="gap-[20px] mb-[30px]">
+          <InputField
+            autoFocus
+            name="email"
+            placeholder="이메일"
+            keyboardType="email-address"
+            returnKeyType="next"
+            inputMode="email"
+            onSubmitEditing={() => passwordRef.current?.focus()}
+          />
+          <InputField
+            ref={passwordRef}
+            name="password"
+            placeholder="비밀번호"
+            returnKeyType="join"
+            secureTextEntry
+          />
+        </View>
+        <CustomButton
+          label="로그인"
+          variant="filled"
+          size="large"
+          onPress={handleSubmit(onSubmit)}
+        />
+      </FormProvider>
     </SafeAreaView>
   );
 };

--- a/src/screens/auth/LoginScreen.tsx
+++ b/src/screens/auth/LoginScreen.tsx
@@ -21,7 +21,7 @@ const LoginScreen = () => {
   });
   const {handleSubmit} = methods;
 
-  const onSubmit = (data: any) => {
+  const onSubmit = (data: LoginFormValues) => {
     loginMutation.mutate(data);
   };
 

--- a/src/screens/auth/SignupScreen.tsx
+++ b/src/screens/auth/SignupScreen.tsx
@@ -1,9 +1,84 @@
-import {Text} from 'react-native';
-import {SafeAreaView} from 'react-native-safe-area-context';
+import CustomButton from '@/components/CustomButton';
+import InputField from '@/components/InputField';
+import useAuth from '@/hooks/useAuth';
+import {SignupFormValues} from '@/types/auth';
+import {signupSchema} from '@/validate/validate';
+import {yupResolver} from '@hookform/resolvers/yup';
+import {useRef} from 'react';
+
+import {FormProvider, useForm} from 'react-hook-form';
+import {View, SafeAreaView, TextInput} from 'react-native';
+
 const SignupScreen = () => {
+  const {signupMutation, loginMutation} = useAuth();
+  const passwordRef = useRef<TextInput | null>(null);
+  const passwordConfirmRef = useRef<TextInput | null>(null);
+  const methods = useForm<SignupFormValues>({
+    defaultValues: {
+      email: '',
+      password: '',
+      confirmPassword: '',
+    },
+    mode: 'onChange',
+    resolver: yupResolver(signupSchema),
+  });
+
+  const {handleSubmit} = methods;
+
+  const onSubmit = (data: SignupFormValues) => {
+    signupMutation.mutate(
+      {
+        email: data.email,
+        password: data.password,
+      },
+      {
+        onSuccess: () => {
+          loginMutation.mutate({
+            email: data.email,
+            password: data.password,
+          });
+        },
+      },
+    );
+  };
+
   return (
-    <SafeAreaView>
-      <Text>Welcome to the Signup Screen</Text>
+    <SafeAreaView className="flex-1 m-[30px]">
+      <FormProvider {...methods}>
+        <View className="gap-[20px] mb-[30px]">
+          <InputField
+            autoFocus
+            name="email"
+            placeholder="이메일"
+            keyboardType="email-address"
+            returnKeyType="next"
+            inputMode="email"
+            onSubmitEditing={() => passwordRef.current?.focus()}
+          />
+          <InputField
+            ref={passwordRef}
+            name="password"
+            secureTextEntry
+            textContentType="oneTimeCode"
+            placeholder="비밀번호"
+            returnKeyType="next"
+            onSubmitEditing={() => passwordConfirmRef.current?.focus()}
+          />
+          <InputField
+            ref={passwordConfirmRef}
+            name="confirmPassword"
+            placeholder="비밀번호 확인"
+            secureTextEntry
+            returnKeyType="done"
+          />
+        </View>
+        <CustomButton
+          label="회원가입"
+          variant="filled"
+          size="large"
+          onPress={handleSubmit(onSubmit)}
+        />
+      </FormProvider>
     </SafeAreaView>
   );
 };

--- a/src/screens/map/MapHomeScreen.tsx
+++ b/src/screens/map/MapHomeScreen.tsx
@@ -1,12 +1,15 @@
 import {SafeAreaView} from 'react-native-safe-area-context';
 import DrawerButton from '@/components/DrawerButton';
 import {Text} from 'react-native';
+import useAuth from '@/hooks/useAuth';
 
 function MapHomeScreen() {
+  const {logoutMutation} = useAuth();
   return (
     <SafeAreaView>
       <DrawerButton />
       <Text>Map Home Screen</Text>
+      <Text onPress={() => logoutMutation.mutate({})}>로그아웃</Text>
     </SafeAreaView>
   );
 }

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -1,0 +1,24 @@
+import {
+  QueryKey,
+  UseMutationOptions,
+  UseQueryOptions,
+} from '@tanstack/react-query';
+import {AxiosError} from 'axios';
+
+type ResponseError = AxiosError<{
+  statusCode: number;
+  message: string;
+  error: string;
+}>;
+
+type UseMutationCustomOptions<TData = unknown, TVariable = unknown> = Omit<
+  UseMutationOptions<TData, ResponseError, TVariable, unknown>,
+  'mutationFn'
+>;
+
+type UseQueryCustomOptions<TQueryFnData = unknown, TData = TQueryFnData> = Omit<
+  UseQueryOptions<TQueryFnData, ResponseError, TData, QueryKey>,
+  'queryKey'
+>;
+
+export type {ResponseError, UseMutationCustomOptions, UseQueryCustomOptions};

--- a/src/types/auth.ts
+++ b/src/types/auth.ts
@@ -1,0 +1,20 @@
+export type SignupFormValues = {
+  email: string;
+  password: string;
+  confirmPassword: string;
+};
+
+export type LoginFormValues = {
+  email: string;
+  password: string;
+};
+
+export type RequestUserType = {
+  email: string;
+  password: string;
+};
+
+export type ResponseToken = {
+  accessToken: string;
+  refreshToken: string;
+};

--- a/src/types/domain.ts
+++ b/src/types/domain.ts
@@ -1,0 +1,31 @@
+interface ImageUri {
+  id?: number;
+  uri: string;
+}
+
+interface Marker {
+  id: number;
+  latitude: number;
+  longitude: number;
+  color: string;
+  score: number;
+}
+
+interface Post extends Marker {
+  title: string;
+  address: string;
+  date: Date | string;
+  description: string;
+  imageUris: ImageUri[];
+  isFavorite?: boolean;
+}
+
+interface Profile {
+  id: number;
+  email: string;
+  nickname: string | null;
+  imageUri: string | null;
+  loginType: 'email' | 'kakao' | 'apple';
+}
+
+export type {ImageUri, Marker, Post, Profile};

--- a/src/utils/encryptStorage.ts
+++ b/src/utils/encryptStorage.ts
@@ -1,0 +1,27 @@
+import EncryptedStorage from 'react-native-encrypted-storage';
+
+// 로컬스토리지와 비슷하지만, 민감한 정보를 암호화하여 저장하는 용도
+
+async function setEncryptStorage<T>(key: string, data: T) {
+  await EncryptedStorage.setItem(key, JSON.stringify(data));
+}
+
+async function getEncryptStorage<T>(key: string): Promise<T | null> {
+  const data = await EncryptedStorage.getItem(key);
+
+  if (!data) {
+    return null;
+  }
+
+  return JSON.parse(data) as T;
+}
+
+async function removeEncryptStorage(key: string) {
+  const data = await getEncryptStorage(key);
+  if (!data) {
+    return;
+  }
+  await EncryptedStorage.removeItem(key);
+}
+
+export {setEncryptStorage, getEncryptStorage, removeEncryptStorage};

--- a/src/utils/header.ts
+++ b/src/utils/header.ts
@@ -1,0 +1,13 @@
+import axiosInstance from '@/api/axios';
+
+function setHeader(key: string, value: string) {
+  axiosInstance.defaults.headers.common[key] = value;
+}
+
+function removeHeader(key: string) {
+  if (axiosInstance.defaults.headers.common[key]) {
+    delete axiosInstance.defaults.headers.common[key];
+  }
+}
+
+export {setHeader, removeHeader};

--- a/src/validate/validate.ts
+++ b/src/validate/validate.ts
@@ -1,0 +1,27 @@
+import * as yup from 'yup';
+const emailSchema = yup
+  .string()
+  .email('유효한 이메일 주소를 입력해주세요.')
+  .required('이메일을 입력해주세요.');
+
+const passwordSchema = yup
+  .string()
+  .min(8, '비밀번호는 최소 8자 이상이어야 합니다.')
+  .matches(/[A-Z]/, '비밀번호에는 최소 하나의 대문자가 포함되어야 합니다.')
+  .matches(/[a-z]/, '비밀번호에는 최소 하나의 소문자가 포함되어야 합니다.')
+  .matches(/[0-9]/, '비밀번호에는 최소 하나의 숫자가 포함되어야 합니다.')
+  .required('비밀번호를 입력해주세요.');
+
+export const loginSchema = yup.object({
+  email: emailSchema,
+  password: passwordSchema,
+});
+
+export const signupSchema = yup.object({
+  email: emailSchema,
+  password: passwordSchema,
+  confirmPassword: yup
+    .string()
+    .oneOf([yup.ref('password')], '비밀번호가 일치하지 않습니다.')
+    .required('비밀번호 확인을 입력해주세요.'),
+});

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,5 +1,5 @@
 /** @type {import('tailwindcss').Config} */
-const colors = require('./src/styles/colors.ts');
+const colors = require('./src/styles/colors.ts').default;
 
 module.exports = {
   // NOTE: Update this to include the paths to all files that contain Nativewind classes.
@@ -11,7 +11,9 @@ module.exports = {
   presets: [require('nativewind/preset')],
   theme: {
     extend: {
-      colors,
+      colors: {
+        color: colors,
+      },
     },
   },
   plugins: [],


### PR DESCRIPTION
# 📌 Pull Request
#2 
## 🧩 작업 내용 (Summary)

- 로그인 연결
- 회원가입 연결
- 로그아웃 연결
- userProfile 연결

## 🛠 변경 사항 (Changes)
- 강의와는 다르게 react-hook-form과 yup을 이용해서 구현
- colors.ts 적용 안되고 있던 문제 해결

## 📱 실행 결과 (Screenshots / Logs)

### iOS

- Simulator:
<img width="525" height="998" alt="스크린샷 2025-12-21 오전 2 22 18" src="https://github.com/user-attachments/assets/d7046eb0-f7e7-4be3-b5de-724875c68383" />
<img width="525" height="998" alt="스크린샷 2025-12-21 오전 2 22 58" src="https://github.com/user-attachments/assets/9af64a94-b8d2-4d22-be74-213be112ce45" />

이메일로 로그인이 여러개인 이유는 추후 소셜 로그인 버튼자리... 그냥 일단 복붙해서 비슷하게 보이는지 확인 용도이다. 추후 수정 예정

### Android

생략

## 🚧 트러블슈팅 (Troubleshooting)

- 문제: 로그인 했을 때 isLogin 상태가 바로 트리거 되지 않음

- 원인: 강의 영상에서 제공해준 것처럼 동일하게 하였지만..?(아닐지도..) 해결 되지 않았고, 강의에서 제공한 로직 상으로 로그인 성공 시 -> 리프레시 토큰을 통해 리프레시 시도, 성공 시 -> profile을 조회해서 성공하면 isLogin을 true로 바꾸는 로직인데.. 흠... 이 강의의 로직에 대해서는 추후 변경을 해보던가 해야겠다.. 여튼 문제는 리프레시 토큰을 통해 리프레시에 성공하였는데 성공해서 바뀐 헤더랑 encryptStorage가 반영되기 전에 요청이 가서 실패하는 것 같았다.

- 해결:  강제로 refetchQueries를 통해 리패치 시켰더니 원하는 대로 동작 하였다.

## 📦 신규 설치 / 변경된 패키지

```bash
pnpm add @hookform/resolvers @tanstack/react-query axios react-hook-form react-native-encrypted-storage yup
```
변경 이유:
- `@hookform/resolvers` : react-hook-form과 yup 연결
- `@tanstack/react-query`: 서버 상태 관리 
- `axios`: HTTP 클라이언트 
- `react-hook-form`: 폼 상태 관리 라이브러리
- `react-native-encrypted-storage`: 암호화된 로컬 저장소 
- `yup`: 스키마 기반 유효성 검증 라이브러리

## 🔗 참고 자료 (Reference)
X

## 번외
몰랐는데 내가 정리해둔 colors.ts가 적용이 안되고 있었따... 해당 부분 수정 완료함!

## ✔️ 체크리스트

- [x] iOS 정상 빌드됨
- [x] Android 정상 빌드됨
- [x] Metro 번들 정상 작동
- [x] 기능 동작 확인
- [x] 코드 리뷰 가능 상태
